### PR TITLE
GitHub CI

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -110,6 +110,7 @@ jobs:
         run: moodle-plugin-ci mustache
 
       - name: Grunt
+        continue-on-error: true # Currently fails. We really ought to get this passing.
         if: ${{ matrix.moodle-branch == 'MOODLE_500_STABLE' }}
         run: moodle-plugin-ci grunt
 


### PR DESCRIPTION
- This runs the tests against Moodle main, 5.1, 5.0, 4.5 and 4.1
- Installation of R makes things quite slow but unavoidable.
- I've set the script to ignore Moodle Code Checker, plugin validation, Mustache lint and Grunt issues for now so we really notice if unit tests/Behat fail. Mustache and Grunt are probably minor to fix. Validation is to do with DB table names which I suspect may not be fixable. STACK experience suggests Code Checker fixing can be mostly achieved automatically using `local/codechecker/vendor/bin/phpcbf . --standard=moodle --extensions=php` - looks like there are around 1100 fixes touching almost every file, though.
- Behat tests currently get 3 attempts to succeed and some of the tests are sometimes requiring more than one attempt. This could be one of those Behat flakiness things or an underlying issue.
